### PR TITLE
[ 開発環境 ] PHPUnit テストをリリース時と run-ci ラベル付き PR のみ実行に変更

### DIFF
--- a/.github/workflows/php_unit_test.yml
+++ b/.github/workflows/php_unit_test.yml
@@ -1,18 +1,16 @@
 name: PHP Unit Test
 
 on:
-    push:
-        branches:
-            - master
-            - develop
     pull_request:
         branches:
             - master
             - develop
             - ^feature/.+
+        types: [opened, reopened, labeled, synchronize]
 
 jobs:
     php_unit:
+        if: contains(github.event.pull_request.labels.*.name, 'run-ci')
         runs-on: ubuntu-latest
         strategy:
             matrix:


### PR DESCRIPTION
## 概要

GitHub Actions の消費削減のため、`php_unit_test.yml`（PHPUnit）のトリガーを見直します。

- `master` / `develop` への **push での自動実行を廃止**
- **PR は `run-ci` ラベルが付いたときのみ**実行（`pull_request` の `types` に `labeled` を追加し、ジョブに `if: contains(labels, 'run-ci')` を付与）
- リリース時（タグ push）の PHPUnit は `release.yml` で従来どおり実行されるため維持

日常の開発では PHPUnit をローカルで実行し、CI での実行はリリース時＋必要な PR（run-ci ラベル）に限定します。

関連: vektor-inc/multi-repo-tasks#24

## 変更内容

`.github/workflows/php_unit_test.yml`
- `on.push` を削除
- `on.pull_request.types` に `[opened, reopened, labeled, synchronize]` を追加
- `php_unit` ジョブに `if: contains(github.event.pull_request.labels.*.name, 'run-ci')` を追加

## 確認手順

1. この PR にラベルが無い状態で、`PHP Unit Test` ワークフローが**起動しない**ことを確認する → PR チェックに PHPUnit が出ない
2. この PR に `run-ci` ラベルを付与する → `PHP Unit Test` ワークフローが起動し、PHPUnit が実行される
3. `master` / `develop` へ push しても `PHP Unit Test` が起動しないこと（マージ後に確認可能）
4. リリース（タグ push）時は `release.yml` 経由で PHPUnit が実行されること（従来どおり・変更なし）

CI 設定のみの変更で、プラグインの動作・ユーザー向け挙動には影響しません。