### PR TITLE
[ 開発環境 ] release.yml の wp-env override ファイル名修正と4桁タグトリガー追加

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ on:
     push:
         tags:
             - '[0-9]+.[0-9]+.[0-9]+'
+            - '[0-9]+.[0-9]+.[0-9]+.[0-9]+'
 
 permissions:
     contents: write
@@ -25,7 +26,7 @@ jobs:
               run: npm run dist
             - name: Setup wp-env override for dist
               run: |
-                  echo '{"plugins":["./dist/${{ env.plugin_name }}"]}' > wp-env.override.json
+                  echo '{"plugins":["./dist/${{ env.plugin_name }}"]}' > .wp-env.override.json
             - name: Start wp-env
               run: |
                   for n in 1 2 3; do npx wp-env start --update && break || [ "$n" -lt 3 ] || exit 1; done
@@ -91,14 +92,14 @@ jobs:
                     [ -f "$f" ] && cp "$f" "dist/${{ env.plugin_name }}/$f" || true
                   done
                   [ -d tests ] && cp -r tests "dist/${{ env.plugin_name }}/tests" || true
-            - name: Create wp-env.override.json for dist
+            - name: Create .wp-env.override.json for dist
               run: |
-                  cat > wp-env.override.json << 'EOF'
+                  cat > .wp-env.override.json << 'EOF'
                   {
                     "plugins": ["./dist/${{ env.plugin_name }}"]
                   }
                   EOF
-            - name: Install several WordPress version by wp-env.override.json
+            - name: Install several WordPress version by .wp-env.override.json
               run: |
                   n=0
                   until [ $n -ge 5 ]


### PR DESCRIPTION
## 概要

リリースワークフロー `release.yml` の C-7 移行不備（親 issue vektor-inc/vk-agents#168 のフォローアップ）を修正します。着手時に実ファイルを検証し、監査で検出された 2 点がいずれも現状該当することを確認したうえで対応しました。

### 変更内容

1. **wp-env override ファイル名を dot 付きに修正**
   - `wp-env.override.json`（先頭ドット無し）→ `.wp-env.override.json`（先頭ドット有り）に修正（smoke_test / php_unit の 2 ジョブ、および step 名の表記統一）。
   - wp-env が自動で読み込むのは `.wp-env.override.json`（ドット有り）のみ。ドット無しファイルは無視され `.wp-env.json`（`"plugins": ["."]` ＝ source ルート）が使われるため、**これまで dist ではなく source を検証していた**。ドット付きにすることで本来の dist 検証に是正。

2. **4 桁タグ対応のトリガーを追加**
   - `on.push.tags` に `'[0-9]+.[0-9]+.[0-9]+.[0-9]+'`（4 セグメント）を追加（既存の 3 セグメントは残置＝加算的変更）。
   - 当リポは 4 桁タグ（`2.19.0.1` / `3.0.0.0` 等）を実運用しているが、3 セグメントパターンは 4 桁タグにフル一致せず Actions が発火しない。実際にタグ `3.0.0.0` は GitHub Release が作られておらず、不発の症状が既に発生していた。

### changelog

GitHub Actions ワークフロー設定の変更のため、`readme.txt` への追記は不要（開発環境扱い・readme.txt にはエンドユーザー向けでない開発環境変更は記載しない方針）。

## テスト（確認手順）

このワークフローはタグ push 時にのみ発火するため、ブラウザ操作での確認対象はありません。差分レビューと、次回リリース時の実タグ push での発火確認で検証します。

### 差分の確認（レビュアー向け）

1. `.github/workflows/release.yml` の diff を開く。
2. `on.push.tags` に 3 セグメント／4 セグメントの 2 パターンが並んでいること → 4 桁タグでもマッチする。
3. override を書き出す 2 箇所（`echo ... > .wp-env.override.json` / `cat > .wp-env.override.json << 'EOF'`）がいずれも **先頭ドット有り** になっていること。
4. リポジトリ内に先頭ドット無しの `wp-env.override.json` 参照が残っていないこと（`grep -n "wp-env.override.json" .github/workflows/release.yml | grep -v '\.wp-env'` が空）。

### 次回リリース時の確認（After）

- 4 桁タグ（例 `x.y.z.w`）を push → `Deploy to WordPress.org` ワークフローが起動する（従来は起動しなかった）。
- smoke_test / php_unit のログで、`.wp-env.override.json` により `./dist/vk-filter-search` がマウントされ、source ではなく dist が検証されている。

関連 issue: https://github.com/vektor-inc/vk-filter-search/issues/177

---

**Task-queue:** https://github.com/vektor-inc/task-queue/issues/278